### PR TITLE
adding numba.vectorize instead of numpy.vectorize

### DIFF
--- a/anicomp.py
+++ b/anicomp.py
@@ -7,12 +7,13 @@ Created on Sun May 22 12:15:34 2016
 
 import matplotlib.pyplot as plt
 import numpy as np
+import numba
 
 #This code is used to create the compactness over thickness plot for a anisotropic gravastars, see this paper for more: https://arxiv.org/abs/0706.1513
 #By commenting out lines 84-86 and un-commenting line 92, the pogram can be used to derive the other plots for anisotropic gravastars in the paper
 #Oh god why
 
-
+@numba.vectorize
 def compute_density(r,r1,r2,density0):
   ''' compute the equation of state, i.e. eq 23 '''
   if r <= r1 and r >= 0:
@@ -39,8 +40,7 @@ def get_grr(r1, r2, M, stepsize):
   #fixing rho_0 in terms of M
   density0 = M*((r2 - r1)**3/(4*np.pi))*np.power(((r2**6 - r1**6)/3) - (3*(r2 + r1)*(r2**5 - r1**5)/5) + (3*r1*r2*(r2**4 - r1**4)/2) + ((r2**3 - 3*r2**2*r1 )*(r2**3 - r1**3)/3) + ((r1**3*(r2 - r1)**3)/3), -1) 
 
-  vfunc = np.vectorize(compute_density)
-  dens=vfunc(r,r1,r2,density0) 
+  dens=compute_density(r,r1,r2,density0)
   mass=np.cumsum(dens*r**2)*np.pi*4*stepsize 
     
   return (1-2*mass/r)
@@ -52,7 +52,7 @@ def is_neg(grr):
     return 1
   else:
     return 0
-  
+
 if __name__ == '__main__':
 
   #parsing arguments (rescaled since the bash script sequence only allows integers, e.g. parse 100 if you want a mass of 1)


### PR DESCRIPTION
I'm seeing ~50% speed increase on compute_density, close to 25% overall.
This does add another dependency but if you don't have numba, you should really fix that.

I've poked around using @numba.jit on your other functions and it can be done with a bit of refactoring but the compile time per run of anicomp.py outpaces the speedup.
